### PR TITLE
Add flat categories endpoint for frontend

### DIFF
--- a/categories/api/v1/serializers.py
+++ b/categories/api/v1/serializers.py
@@ -17,3 +17,22 @@ class CategorySerializer(serializers.ModelSerializer):
             'parent',
             'children',
         )
+
+
+class CategoryFlatSerializer(serializers.ModelSerializer):
+    """Flat serializer for categories without nested children"""
+    parent_name = serializers.CharField(source='parent.name', read_only=True)
+
+    class Meta:
+        model = Category
+        fields = (
+            'id',
+            'name',
+            'type',
+            'description',
+            'color',
+            'parent',
+            'parent_name',
+            'created_at',
+            'edited_at',
+        )

--- a/categories/api/v1/views.py
+++ b/categories/api/v1/views.py
@@ -1,9 +1,12 @@
+from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 from django_filters import rest_framework as django_filters
 from rest_framework import viewsets, permissions, pagination, filters
+from rest_framework.decorators import action
+from rest_framework.response import Response
 from categories.models import Category
-from .serializers import CategorySerializer
-from drf_spectacular.utils import extend_schema
+from .serializers import CategorySerializer, CategoryFlatSerializer
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 
 
 class CategoryFilter(django_filters.FilterSet):
@@ -29,3 +32,56 @@ class CategoryVeiwSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = [filters.SearchFilter, DjangoFilterBackend, filters.OrderingFilter]
     ordering_fields = ['name', 'created_at', 'edited_at']
     ordering = ['name']
+
+    @extend_schema(
+        summary="Get flat list of categories",
+        description="Returns all categories in a flat list format (not hierarchical). "
+                    "Useful for dropdowns and simple lists where you need all categories at once.",
+        parameters=[
+            OpenApiParameter(
+                name='type',
+                type=str,
+                location=OpenApiParameter.QUERY,
+                description='Filter by category type (expense or income)',
+                enum=['expense', 'income'],
+                required=False
+            ),
+        ],
+        responses={200: CategoryFlatSerializer(many=True)}
+    )
+    @action(detail=False, methods=['get'], url_path='flat', url_name='flat', pagination_class=None)
+    def flat(self, request):
+        """
+        Get all categories in a flat list format.
+        
+        This endpoint returns all categories (both root and children) in a single
+        flat list, without nested hierarchy. Useful for frontend components that
+        need a simple list of all categories.
+        
+        Query parameters:
+        - type: Filter by category type ('expense' or 'income')
+        """
+        queryset = Category.objects.all().select_related('parent')
+        
+        # Filter by type if provided
+        category_type = request.query_params.get('type', None)
+        if category_type:
+            queryset = queryset.filter(type=category_type)
+        
+        # Apply search if provided
+        search = request.query_params.get('search', None)
+        if search:
+            queryset = queryset.filter(
+                Q(name__icontains=search) | 
+                Q(description__icontains=search)
+            )
+        
+        # Apply ordering
+        ordering = request.query_params.get('ordering', 'name')
+        if ordering.lstrip('-') in ['name', 'type', 'created_at', 'edited_at']:
+            queryset = queryset.order_by(ordering)
+        else:
+            queryset = queryset.order_by('name')
+        
+        serializer = CategoryFlatSerializer(queryset, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
- Add CategoryFlatSerializer for flat category list without nested children
- Add /flat endpoint to CategoryViewSet that returns all categories in flat format
- Support filtering by type (expense/income), search, and ordering
- Disable pagination for flat endpoint to return all categories at once
- Remove redundant parent_id field (parent already contains the ID)